### PR TITLE
Fix - empty xilogravura url field on review page

### DIFF
--- a/src/pages/cordels/review/CordelReview.tsx
+++ b/src/pages/cordels/review/CordelReview.tsx
@@ -147,6 +147,7 @@ export default function CordelReview() {
               id="xilogravuraUrl"
               defaultValue={cordel.xilogravuraUrl}
               autoComplete="xilogravuraUrl"
+              {...register("xilogravuraUrl")}
             />
             <TextField
               variant="outlined"


### PR DESCRIPTION
Add register hook to the field

